### PR TITLE
fix: reading operators_list and logging info

### DIFF
--- a/bentoctl/operator/registry.py
+++ b/bentoctl/operator/registry.py
@@ -35,9 +35,8 @@ class OperatorRegistry:
         self.operator_file = os.path.join(self.path, "operator_list.json")
         self.operators_list = {}
         if os.path.exists(self.operator_file):
-            self.operators_list = json.loads(
-                self.operator_file.read_text(encoding="utf-8")
-            )
+            with open(self.operator_file) as f:
+                self.operators_list = json.load(f)
 
     def list(self):
         return self.operators_list
@@ -84,7 +83,7 @@ class OperatorRegistry:
         if os.path.exists(name):
             content_path = name
             repo_url = None
-            logger.log(f"Adding an operator from local file system ({content_path})...")
+            logger.info(f"Adding an operator from local file system ({content_path})...")
         elif (
             _is_official_operator(name)
             or _is_github_repo(name)


### PR DESCRIPTION
quick fix for reading the operator list and logging info that everything works fine when adding an operator 