### PR TITLE
ci: run ci when pushed to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: Bentoctl-CI
 
 on:
   push:
-    branches: [ protype ]
+    branches: [ main ]
   pull_request:
-    branches: [ prototype ]
+    branches: [ main ]
 #  schedule:
 #    - cron '0 2 * * *'
 

--- a/tests/test_operator_registry.py
+++ b/tests/test_operator_registry.py
@@ -132,15 +132,6 @@ def test_registry_remove(op_reg):
     assert "testop" in op_reg.list()
     op_reg.remove("testop")
     assert "testop" not in op_reg.list()
-    assert testop_path.exists()
-    # clean up the testop dir inside BENTOCTL_HOME/operators
-    shutil.rmtree(testop_path)
-
-    # remove directory also
-    op_reg.add(TESTOP_PATH)
-    assert "testop" in op_reg.list()
-    op_reg.remove("testop", remove_from_disk=True)
-    assert "testop" not in op_reg.list()
     assert not testop_path.exists()
 
     with pytest.raises(OperatorNotFound):


### PR DESCRIPTION
set GitHub action to trigger CI when there is a PR to `main` branch instead of the old `prototype` branch