### PR TITLE
fix: 'type' is not a required value for the schema

### DIFF
--- a/bentoctl/cli/__init__.py
+++ b/bentoctl/cli/__init__.py
@@ -141,7 +141,8 @@ def describe(file):
     """
     try:
         info_json = describe_deployment(deployment_config_path=file)
-        pprint(info_json)
+        if info_json is not None:
+            pprint(info_json)
     except BentoctlException as e:
         e.show()
         sys.exit(1)

--- a/bentoctl/deployment_config.py
+++ b/bentoctl/deployment_config.py
@@ -57,10 +57,10 @@ def remove_help_message(schema):
     for field, rules in schema.items():
         if "help_message" in rules:
             del rules["help_message"]
-        if rules["type"] == "dict":
-            rules["schema"] = remove_help_message(rules["schema"])
-        elif rules["type"] == "list":
-            rules["schema"] = remove_help_message({"list_item": rules["schema"]})[
+        if rules.get("type") == "dict":
+            rules["schema"] = remove_help_message(rules.get("schema"))
+        elif rules.get("type") == "list":
+            rules["schema"] = remove_help_message({"list_item": rules.get("schema")})[
                 "list_item"
             ]
         schema[field] = rules


### PR DESCRIPTION
- also don't print out the description in case the `describe()` function returns `None`. This is in case operators print the description themselves without parsing.