### PR TITLE
feat: Add support for display operator notes

### DIFF
--- a/bentoctl/cli/operator_management.py
+++ b/bentoctl/cli/operator_management.py
@@ -1,6 +1,8 @@
 import click
 import cloup
 from rich.prompt import Confirm
+from rich.console import Console
+from rich.markdown import Markdown
 
 from bentoctl.cli.utils import BentoctlCommandGroup
 from bentoctl.exceptions import BentoctlException
@@ -9,6 +11,12 @@ from bentoctl.operator.constants import OFFICIAL_OPERATORS
 from bentoctl.utils import print_operator_list
 
 local_operator_registry = get_local_operator_registry()
+
+
+def display_operator_notes(notes):
+    console = Console()
+    md = Markdown(notes)
+    console.print(md)
 
 
 def get_operator_management_subcommands():
@@ -82,6 +90,8 @@ def get_operator_management_subcommands():
             operator_name = local_operator_registry.add(name)
             if operator_name is not None:
                 click.echo(f"Added {operator_name}!")
+                operator = local_operator_registry.get(operator_name)
+                display_operator_notes(operator.notes)
             else:
                 click.echo(
                     f"Unable to add operator. `{name}` did not match any of the "
@@ -132,6 +142,20 @@ def get_operator_management_subcommands():
         try:
             local_operator_registry.update(name)
             click.echo(f"Operator '{name}' updated!")
+        except BentoctlException as e:
+            e.show()
+
+    @operator_management.command()
+    @click.argument("name")
+    def describe(name):  # pylint: disable=unused-variable
+        """
+        Display operator notes and details.
+
+        This will display the operator notes in the CLI.
+        """
+        try:
+            operator = local_operator_registry.get(name)
+            display_operator_notes(operator.notes)
         except BentoctlException as e:
             e.show()
 

--- a/bentoctl/operator/operator.py
+++ b/bentoctl/operator/operator.py
@@ -15,6 +15,11 @@ from bentoctl.utils import console
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_OPERATOR_NOTES = """\
+# Operator {} does not have specific notes.
+"""
+
+
 class Operator:
     def __init__(self, path):
         self.path = Path(path)
@@ -74,6 +79,14 @@ class Operator:
 
     def _load_operator_module(self):
         return _import_module(self.module_name, self.path)
+
+    @property
+    def notes(self):
+        if os.path.exists(os.path.join(self.path, "NOTES.md")):
+            with open(os.path.join(self.path, "NOTES.md"), "r") as f:
+                return f.read()
+        else:
+            return DEFAULT_OPERATOR_NOTES.format(self.operator_name)
 
 
 def _import_module(module_name, path):

--- a/tests/test-operator/NOTES.md
+++ b/tests/test-operator/NOTES.md
@@ -1,0 +1,12 @@
+## This is test operator 
+
+1. first
+2. second
+3. third
+
+```
+code block
+```
+
+> quote
+


### PR DESCRIPTION
### Description

Add CLI command `bentoctl operator describe operator_name` to display any additional markdown notes from the operator.


![Screen Shot 2022-02-11 at 2 28 07 PM](https://user-images.githubusercontent.com/670949/153679320-cc324881-1cdd-4836-a73f-bafd0025c50d.png)

