### PR TITLE
fix: calling the bentoml's track() with incorrect CliEvent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ on:
 #    - cron '0 2 * * *'
 
 env:
-  BENTOCTL_DO_NOT_TRACK = True
-  BENTOML_DO_NOT_TRACK = True
+  BENTOCTL_DO_NOT_TRACK: True
+  BENTOML_DO_NOT_TRACK: True
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 #  schedule:
 #    - cron '0 2 * * *'
 
+env:
+  BENTOCTL_DO_NOT_TRACK = True
+  BENTOML_DO_NOT_TRACK = True
+
 jobs:
 
   lint_and_format:

--- a/bentoctl/cli/utils.py
+++ b/bentoctl/cli/utils.py
@@ -76,19 +76,19 @@ class BentoctlCommandGroup(click.Group):
                 )
             elif cmd_group.name == "operator":
 
-                def get_tracking_event(return_value):  # pylint: disable=unused-argument
+                def get_tracking_event(_):  # pylint: disable=unused-argument
                     return BentoctlCliEvent(
                         cmd_group.name, command_name, operator=kwargs.get("name", None)
                     )
 
             else:
 
-                def get_tracking_event(ret):  # pylint: disable=unused-argument
+                def get_tracking_event(_):  # pylint: disable=unused-argument
                     return BentoctlCliEvent(cmd_group.name, command_name)
 
             try:
                 return_value = func(*args, **kwargs)
-                event = get_tracking_event(return_value=return_value)
+                event = get_tracking_event(return_value)
                 duration_in_ms = time.time_ns() - start_time
                 event.duration_in_ms = duration_in_ms / 1e6
                 track(event)

--- a/bentoctl/cli/utils.py
+++ b/bentoctl/cli/utils.py
@@ -9,7 +9,7 @@ from bentoctl.exceptions import BentoctlException
 from bentoctl.utils import set_debug_mode
 from bentoctl.utils.usage_stats import (
     BENTOML_DO_NOT_TRACK,
-    CliEvent,
+    BentoctlCliEvent,
     cli_events_map,
     track,
 )
@@ -77,14 +77,14 @@ class BentoctlCommandGroup(click.Group):
             elif cmd_group.name == "operator":
 
                 def get_tracking_event(return_value):  # pylint: disable=unused-argument
-                    return CliEvent(
+                    return BentoctlCliEvent(
                         cmd_group.name, command_name, operator=kwargs.get("name", None)
                     )
 
             else:
 
                 def get_tracking_event(ret):  # pylint: disable=unused-argument
-                    return CliEvent(cmd_group.name, command_name)
+                    return BentoctlCliEvent(cmd_group.name, command_name)
 
             try:
                 return_value = func(*args, **kwargs)

--- a/bentoctl/utils/usage_stats.py
+++ b/bentoctl/utils/usage_stats.py
@@ -1,4 +1,9 @@
+import typing as t
+
+import attr
+
 # These are internal apis. We will need to make sure update these when BentoML changes.
+from bentoml._internal.utils.analytics.schemas import EventMeta
 from bentoml._internal.utils.analytics.usage_stats import (  # noqa pylint: disable=unused-import
     BENTOML_DO_NOT_TRACK,
     do_not_track,
@@ -8,26 +13,15 @@ from bentoml._internal.utils.analytics.usage_stats import (  # noqa pylint: disa
 from bentoctl import __version__
 
 
-class CliEvent:
-    def __init__(
-        self,
-        cmd_group,
-        cmd_name,
-        duration_in_ms=None,
-        error_type=None,
-        return_code=None,
-        operator=None,
-        version=None,
-    ):
-        self.cmd_group = cmd_group
-        self.cmd_name = cmd_name
-        self.duration_in_ms = duration_in_ms
-        self.error_type = error_type
-        self.return_code = return_code
-        self.operator = operator
-        self.version = version
-        self.bentoctl_version = __version__
-        self.event_name = "bentoctl_cli"
+@attr.define
+class BentoctlCliEvent(EventMeta):
+    cmd_group: str
+    cmd_name: str
+    duration_in_ms: t.Optional[t.Any] = attr.field(default=None)
+    error_type: t.Optional[str] = attr.field(default=None)
+    return_code: t.Optional[int] = attr.field(default=None)
+    operator: t.Optional[str] = attr.field(default=None)
+    version: t.Optional[str] = attr.field(default=None)
 
 
 def _bentoctl_event(cmd_group, cmd_name, return_value=None):
@@ -37,14 +31,14 @@ def _bentoctl_event(cmd_group, cmd_name, return_value=None):
             deployment_config.bento.tag.version if deployment_config.bento else None
         )
 
-        return CliEvent(
+        return BentoctlCliEvent(
             cmd_group,
             cmd_name,
             operator=deployment_config.operator_name,
             version=version,
         )
     else:
-        return CliEvent(cmd_group, cmd_name)
+        return BentoctlCliEvent(cmd_group, cmd_name)
 
 
 cli_events_map = {"bentoctl": _bentoctl_event}

--- a/bentoctl/utils/usage_stats.py
+++ b/bentoctl/utils/usage_stats.py
@@ -23,6 +23,7 @@ class BentoctlCliEvent(EventMeta):
     return_code: t.Optional[int] = attr.field(default=None)
     operator: t.Optional[str] = attr.field(default=None)
     version: t.Optional[str] = attr.field(default=None)
+    bentoctl_version: str = __version__
 
 
 def _bentoctl_event(

--- a/bentoctl/utils/usage_stats.py
+++ b/bentoctl/utils/usage_stats.py
@@ -11,6 +11,7 @@ from bentoml._internal.utils.analytics.usage_stats import (  # noqa pylint: disa
 )
 
 from bentoctl import __version__
+from bentoctl.deployment_config import DeploymentConfig
 
 
 @attr.define
@@ -24,7 +25,9 @@ class BentoctlCliEvent(EventMeta):
     version: t.Optional[str] = attr.field(default=None)
 
 
-def _bentoctl_event(cmd_group, cmd_name, return_value=None):
+def _bentoctl_event(
+    cmd_group: str, cmd_name: str, return_value: t.Optional[DeploymentConfig] = None
+):
     if return_value is not None:
         deployment_config = return_value
         version = (


### PR DESCRIPTION
<!--- Thanks for sending a pull request!

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).

- feat: (new feature for the user, not a new feature for build script)
- fix: (bug fix for the user, not a fix to a build script)
- docs: (changes to the documentation)
- style: (formatting, missing semicolons, etc; no production code change)
- refactor: (refactoring production code, eg. renaming a variable)
- perf: (code changes that improve performance)
- test: (adding missing tests, refactoring tests; no production code change)
- chore: (updating grunt tasks etc; no production code change)
- build: (changes that affect the build system or external dependencies)
- ci: (changes to configuration files and scripts)
- revert: (reverts a previous commit)
-->

#### Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
Curently bentoctl CliEvent is not defined with attrs and hence does not get serialized completely 
when calling `track()` function in bentoml.
closes: <!--- reference any issue that this PR will close -->
