### PR TITLE
fix: pass the --load flag with buildx build to make result img available

### DIFF
--- a/bentoctl/docker_utils.py
+++ b/bentoctl/docker_utils.py
@@ -75,7 +75,7 @@ def generate_deployable_container(
             "cgroup_parent": None,
             "iidfile": None,
             "labels": None,
-            "load": True, # load the image after build into system-wide docker images
+            "load": True,  # loading built container to local registry.
             "metadata_file": None,
             "network": None,
             "no_cache": False,

--- a/bentoctl/docker_utils.py
+++ b/bentoctl/docker_utils.py
@@ -75,7 +75,7 @@ def generate_deployable_container(
             "cgroup_parent": None,
             "iidfile": None,
             "labels": None,
-            "load": None,
+            "load": True, # load the image after build into system-wide docker images
             "metadata_file": None,
             "network": None,
             "no_cache": False,


### PR DESCRIPTION
<!--- Thanks for sending a pull request!

Please make sure to read the contribution guidelines, then fill out the blanks below before requesting a code review.

Name your Pull Request with one of the following prefixes, e.g. "feat: add support for PyTorch", to indicate the type of changes proposed. This is based on the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).

- feat: (new feature for the user, not a new feature for build script)
- fix: (bug fix for the user, not a fix to a build script)
- docs: (changes to the documentation)
- style: (formatting, missing semicolons, etc; no production code change)
- refactor: (refactoring production code, eg. renaming a variable)
- perf: (code changes that improve performance)
- test: (adding missing tests, refactoring tests; no production code change)
- chore: (updating grunt tasks etc; no production code change)
- build: (changes that affect the build system or external dependencies)
- ci: (changes to configuration files and scripts)
- revert: (reverts a previous commit)
-->

#### Description
<!--- Describe your changes in detail -->
<!--- Attach screenshots here if appropriate. -->
loads the final image build into system-wide docker. This fixes the docker image missing error when the docker buildx builder is a container-based one. @ssheng had experienced this issue on his system
closes: <!--- reference any issue that this PR will close -->
