### PR TITLE
chore: adding codeowners for bentoctl

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jjmachan


### PR DESCRIPTION
This PR tries to add CODEOWNERS for bentoctl. Maybe we can also pull in more member to
maintain bentoctl with @jjmachan

Signed-off-by: Aaron Pham <29749331+aarnphm@users.noreply.github.com>
