### PR TITLE
fix: prevent deleting temp directory before docker build process

### DIFF
--- a/bentoctl/deployment_config.py
+++ b/bentoctl/deployment_config.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import os
+import shutil
 import typing as t
 from contextlib import contextmanager
 from pathlib import Path
@@ -254,7 +255,9 @@ class DeploymentConfig:
                 model = get_model(model_info.tag)
                 model_fs = models_fs.makedirs(model_info.tag.path())
                 fs.mirror.mirror(model.path, model_fs)
-            yield temp_fs.getsyspath("/")
+            new_temp_dir = temp_fs.getsyspath("/")[:-1] + "-copy"
+            shutil.copytree(temp_fs.getsyspath("/"), new_temp_dir)
+            yield new_temp_dir
 
     def create_deployable(self, destination_dir=os.curdir) -> str:
         """

--- a/bentoctl/docker_utils.py
+++ b/bentoctl/docker_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 import typing as t
 from collections import OrderedDict
 
@@ -118,6 +119,7 @@ def generate_deployable_container(
         container.health("buildx")
         backend = container.get_backend("buildx")
         backend.build(**buildx_args)
+        shutil.rmtree(buildx_args["context_path"])
 
 
 def tag_docker_image(image_name, image_tag):


### PR DESCRIPTION
#### Description

Tried to run Google Cloud Run deployment [example](https://github.com/bentoml/google-cloud-run-deploy) and encountered problem with non existing temp directory during `bentoctl build` command execution. It turned out that when function `_prepare_bento_dir` returns path to temporary directory it was already removed from FS. I added ugly workaround to make it work.

Logs:
```bash
$ poetry run bentoctl build -b sklearn-pipeline-service:latest -f deployment_config.yaml 
Traceback (most recent call last):
  File "/home/user/praca/zenml_template/.venv/bin/bentoctl", line 8, in <module>
    sys.exit(bentoctl())
  File "/home/user/praca/zenml_template/.venv/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/user/praca/zenml_template/.venv/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/user/praca/zenml_template/.venv/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/user/praca/zenml_template/.venv/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/user/praca/zenml_template/.venv/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/user/praca/zenml_template/.venv/lib/python3.10/site-packages/bentoctl/cli/utils.py", line 92, in wrapper
    return_value = func(*args, **kwargs)
  File "/home/user/praca/zenml_template/.venv/lib/python3.10/site-packages/bentoctl/cli/utils.py", line 57, in wrapper
    return func(*args, **kwargs)
  File "/home/user/praca/zenml_template/.venv/lib/python3.10/site-packages/bentoctl/cli/utils.py", line 26, in wrapper
    return func(*args, **kwargs)
  File "/home/user/praca/zenml_template/.venv/lib/python3.10/site-packages/bentoctl/cli/__init__.py", line 316, in build
    generate_deployable_container(
  File "/home/user/praca/zenml_template/.venv/lib/python3.10/site-packages/bentoctl/docker_utils.py", line 120, in generate_deployable_container
    backend.build(**buildx_args)
  File "/home/user/praca/zenml_template/.venv/lib/python3.10/site-packages/bentoml/_internal/container/base.py", line 186, in build
    return subprocess.check_output(commands, cwd=context_path, env=env)
  File "/usr/lib/python3.10/subprocess.py", line 421, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 503, in run
    with Popen(*popenargs, **kwargs) as process:
  File "/usr/lib/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.10/subprocess.py", line 1863, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpmaualbd1fsTempFS/'
```

After code changes:
```bash
$ poetry run bentoctl build -b sklearn-pipeline-service:latest -f deployment_config.yaml 
[+] Building 7.1s (16/16) FINISHED                                                                                                                                   docker:default
 => [internal] load build definition from Dockerfile                                                                                                                           0.0s
 => => transferring dockerfile: 1.61kB                                                                                                                                         0.0s
 => [internal] load .dockerignore                                                                                                                                              0.0s
 => => transferring context: 2B                                                                                                                                                0.0s
 => [internal] load metadata for docker.io/library/python:3.10-slim                                                                                                            1.7s
 => [ 1/11] FROM docker.io/library/python:3.10-slim@sha256:ef44c53813f71871130462fcd1cf77df9a3a468ed7730b402e1216e21ed8fe4f                                                    0.0s
 => => resolve docker.io/library/python:3.10-slim@sha256:ef44c53813f71871130462fcd1cf77df9a3a468ed7730b402e1216e21ed8fe4f                                                      0.0s
 => [internal] load build context                                                                                                                                              1.8s
 => => transferring context: 520.29MB                                                                                                                                          1.8s
 => CACHED [ 2/11] RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache                      0.0s
 => CACHED [ 3/11] RUN set -eux &&     apt-get update -y &&     apt-get install -q -y --no-install-recommends --allow-remove-essential         ca-certificates gnupg2 bash bu  0.0s
 => CACHED [ 4/11] RUN groupadd -g 1034 -o bentoml && useradd -m -u 1034 -g 1034 -o -r bentoml                                                                                 0.0s
 => CACHED [ 5/11] RUN mkdir /home/bentoml/bento && chown bentoml:bentoml /home/bentoml/bento -R                                                                               0.0s
 => CACHED [ 6/11] WORKDIR /home/bentoml/bento                                                                                                                                 0.0s
 => CACHED [ 7/11] COPY --chown=bentoml:bentoml ./env/python ./env/python/                                                                                                     0.0s
 => CACHED [ 8/11] RUN bash -euxo pipefail /home/bentoml/bento/env/python/install.sh                                                                                           0.0s
 => [ 9/11] COPY --chown=bentoml:bentoml . ./                                                                                                                                  1.5s
 => [10/11] RUN rm -rf /var/lib/{apt,cache,log}                                                                                                                                0.2s
 => [11/11] RUN chmod +x /home/bentoml/bento/env/docker/entrypoint.sh                                                                                                          0.3s
 => exporting to image                                                                                                                                                         1.5s
 => => exporting layers                                                                                                                                                        1.5s
 => => writing image sha256:7a8f80f104878d93fbdd31a20b637a6fa6422427a1324881d68351fad18af033                                                                                   0.0s
 => => naming to docker.io/library/google-cloud-run-sklearn-pipeline-service:qu6wo3gb2wzj3x5u                                                                                  0.0s
Created the repository quickstart
The push refers to repository [gcr.io/adam-wawrzynski-sandbox/quickstart]
qu6wo3gb2wzj3x5u: digest: sha256:46ade0540d140841a73a82d21e037933ad3d638ec60608a73635b8f6beec5713 size: 3460
490d74d4384b: Pushed 
78c36977bcad: Pushed 
e9511ab5cf18: Pushed 
2239b03e600a: Layer already exists 
32e4bb8936e1: Layer already exists 
5f70bf18a086: Layer already exists 
68cfdfec1fb2: Layer already exists 
9a2cb7e03151: Layer already exists 
855b762a5205: Layer already exists 
0b840933af6e: Layer already exists 
d3a090682432: Layer already exists 
c6d948842d1e: Layer already exists 
760fe20c9771: Layer already exists 
da5d55102092: Layer already exists 
fb1bd2fc5282: Layer already exists 
🚀 Image pushed!
✨ generated template files.
  - ./bentoctl.tfvars

bentoctl has built and pushed the bento and generated the terraform files 🎉

Now follow the steps below to use terraform to carry out the deployment
1. Initialise the terraform working directory.
$ terraform init

2. Run terraform plan to see the changes that will take place
$ terraform plan -var-file bentoctl.tfvars

3. Apply the changes to create the actual infrastructure
$ terraform apply -var-file bentoctl.tfvars

To cleanup all the resources and delete the repositories created run
$ bentoctl destroy

---
There is also an experimental command that you can use.
To create the resources specifed run this after the build command.
$ bentoctl apply

To cleanup all the resources created and delete the registry run
$ bentoctl destroy

```
